### PR TITLE
Downgrade ctools to 3.7.0 to fix pathauto conflict.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
         }
     ],
     "require": {
+        "drupal/ctools": "3.7.0",
         "drush/drush": "^10",
         "pantheon-upstreams/upstream-configuration": "*"
     },


### PR DESCRIPTION
Need to test with the upstream to make sure it's applied after pathauto requirements are run.