### PR TITLE
update Drupal to 9.4.8 and Php to >=8.1.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -120,7 +120,7 @@
         "preferred-install": "dist",
         "sort-packages": true,
         "platform": {
-            "php": "8.1.6"
+            "php": "8.1"
         },
         "allow-plugins": {
             "composer/installers": true,

--- a/composer.json
+++ b/composer.json
@@ -117,7 +117,7 @@
         "preferred-install": "dist",
         "sort-packages": true,
         "platform": {
-            "php": "7.4"
+            "php": "8.1.6"
         },
         "allow-plugins": {
             "composer/installers": true,

--- a/pantheon.upstream.yml
+++ b/pantheon.upstream.yml
@@ -2,7 +2,7 @@ api_version: 1
 web_docroot: true
 # See https://pantheon.io/docs/pantheon-yml/#enforce-https--hsts for valid values.
 enforce_https: transitional
-php_version: 7.4
+php_version: 8.1
 database:
   version: 10.4
 drush_version: 10

--- a/upstream-configuration/composer.json
+++ b/upstream-configuration/composer.json
@@ -8,10 +8,10 @@
         }
     ],
     "require": {
-        "php": ">=7.3",
+        "php": ">=8.1.6",
         "composer/installers": "v1.11.0",
-        "drupal/core-composer-scaffold": "9.3.22",
-        "drupal/core-recommended": "9.3.22",
+        "drupal/core-composer-scaffold": "9.4.8",
+        "drupal/core-recommended": "9.4.8",
         "pantheon-systems/drupal-integrations": "9.0.2",
         "cweagans/composer-patches": "1.7.1",
         "zaporylie/composer-drupal-optimizations": "1.2.0",
@@ -83,5 +83,5 @@
         "drupal/field_states_ui": "2.0",
         "drupal/ctools": "^3.11.0"
     },
-    "version": "0.1.111"
+    "version": "0.2.0"
 }


### PR DESCRIPTION
https://asudev.jira.com/browse/WS2-1443

We will need to test this for updating existing sites. To do this, you can clone any WS2 site that is currently on the 2.7.0 release to your local development environment. Then, apply the patch you can download here https://drive.google.com/file/d/1gmDHCGiqAGJm3jbUnJP20NoXJ75DyVxd/view?usp=sharing by navigating within your terminal to the "web" directory within the repository and running `git apply ws2-1334-for-ws2-270.patch`. Then you can run `composer update -W` to update Drupal with all of its dependencies. What results should be a clean upgrade for Drupal and Php. Then run `update.php` and rebuild the cache. Then (in a real-world scenario) the configs would need to be exported and committed to the git repository. If you get an error on your local environment that says something like `Fatal error: Composer detected issues in your platform: Your Composer dependencies require a PHP version ">= 8.1.6". You are running 8.0.21. in /var/www/html/vendor/composer/platform_check.php on line 24`, this is because DDEV's default Php version is 8.0. You will need to open the .ddev/config.yml file and change the php_version value from 8.0 to 8.1. Then run `ddev restart`, and that should solve the problem. I don't know how this would work on Lando. You can check to see if Drupal and Php have updated by going to  "/admin/reports/status" where you can check the Drupal and Php versions.

To test this release on a newly spun up site, you can do it using the "[TESTING ONLY] Webspark Release Testing" repository. Since this is only a branch of the master, you will need to make changes manually like above. The patch for this change is: https://drive.google.com/file/d/11YaFZZI5rwjYb7vMXGu_zR-IdJyDK0Iy/view?usp=sharing.

We are upgrading to Php 8.1.6 or higher due to a discovered bug between 8.1.0 and 8.1.5. We could have updated to 8.0, but Drupal recommends 8.1.6 for Drupal 9.4.4 and higher.

I have created a document about updating Webspark sites that hopefully will help people with this upgrade. You can view it here: https://docs.google.com/document/d/1nN8HZxxJIYC6vMEzBoCB3EvIpCREaJI5UUx3mXV3DRY/edit?usp=sharing

Also, I have aggregated all of the Drupal release notes for Drupal 9.4.0 through 9.4.8 and highlighted the important changes in yellow.  You can view that document here: https://docs.google.com/document/d/15dvw8WEIPTCZI2mCFqB5EttcB7f32TsE/edit?usp=sharing&ouid=118140069207486043797&rtpof=true&sd=true.

P.S. I accidentally named this branch wrong. It should be WS2-1443, but I accidentally did WS2-1334. Oops.