### PR TITLE
WS2-1464: Bring the contributed modules up to their latest recommended versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         }
     ],
     "require": {
-        "drush/drush": "^10",
+        "drush/drush": "^11",
         "pantheon-upstreams/upstream-configuration": "*"
     },
     "conflict": {

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "enable-patching": true,
         "patches": {
             "drupal/radix": {
-                "3053579: Integrate with OffCanvas (Layout Builder)": "https://www.drupal.org/files/issues/2020-10-20/3053579-25_0.patch"
+                "3053579: Integrate with OffCanvas (Layout Builder)": "https://www.drupal.org/files/issues/2021-12-15/3053579-32.patch"
             },
             "drupal/paragraphs" : {
                 "2901390: fixing issue langcode cannot be null":  "https://www.drupal.org/files/issues/2021-05-03/paragraphs-2901390-82-withtests.patch"

--- a/composer.json
+++ b/composer.json
@@ -56,9 +56,6 @@
             "drupal/radix": {
                 "3053579: Integrate with OffCanvas (Layout Builder)": "https://www.drupal.org/files/issues/2021-12-15/3053579-32.patch"
             },
-            "drupal/paragraphs" : {
-                "2901390: fixing issue langcode cannot be null":  "https://www.drupal.org/files/issues/2021-05-03/paragraphs-2901390-82-withtests.patch"
-            },
             "drupal/fakeobjects" : {
                 "3002953: Fix js plugin seems to be missing":  "https://www.drupal.org/files/issues/2020-06-22/fakeobjects-missing_plugin-3002953-5.patch"
             },

--- a/composer.json
+++ b/composer.json
@@ -75,6 +75,9 @@
             },
             "drupal/linkit": {
                 "2877535: Fix issue with path alias": "https://www.drupal.org/files/issues/2022-06-07/2877535-39.patch"
+            },
+            "drupal/allowed_formats": {
+                "3269869: Drupal 10 compatibility": "https://git.drupalcode.org/project/allowed_formats/-/commit/9b52e52.patch"
             }
         },
         "installer-paths": {

--- a/upstream-configuration/composer.json
+++ b/upstream-configuration/composer.json
@@ -54,7 +54,7 @@
         "asuwebplatforms/webspark_module_asu_breadcrumb": "1.0.1",
         "asuwebplatforms/webspark-module-asu_react_core": "1.4.0",
         "asuwebplatforms/webspark-module-asu_components_appearance": "1.0.1",
-        "drupal/layout_section_classes": "1.1.0",
+        "drupal/layout_section_classes": "1.2.0",
         "drupal/field_group": "3.4.0",
         "drupal/metatag": "1.19.0",
         "asuwebplatforms/webspark-module-webspark_ckeditor_plugins": "1.0.6",

--- a/upstream-configuration/composer.json
+++ b/upstream-configuration/composer.json
@@ -83,5 +83,5 @@
         "drupal/field_states_ui": "2.0",
         "drupal/ctools": "^3.11.0"
     },
-    "version": "0.2.0"
+    "version": "0.2.1"
 }

--- a/upstream-configuration/composer.json
+++ b/upstream-configuration/composer.json
@@ -77,7 +77,7 @@
         "drupal/schema_metatag": "2.3",
         "drupal/editoria11y": "1.0",
         "drupal/decorative_image_widget":"1.0.0-alpha4",
-        "drupal/block_field": "1.0.0-rc2",
+        "drupal/block_field": "1.0.0-rc4",
         "asuwebplatforms/webspark-module-webspark_cas": "1.0.1",
         "asuwebplatforms/webspark-module-webspark_webdir": "1.1.0",
         "drupal/field_states_ui": "2.0",

--- a/upstream-configuration/composer.json
+++ b/upstream-configuration/composer.json
@@ -75,7 +75,7 @@
         "drupal/robotstxt": "1.4",
         "drupal/captcha": "1.5",
         "drupal/schema_metatag": "2.3",
-        "drupal/editoria11y": "1.0",
+        "drupal/editoria11y": "2.0.2",
         "drupal/decorative_image_widget":"1.0.0-alpha4",
         "drupal/block_field": "1.0.0-rc4",
         "asuwebplatforms/webspark-module-webspark_cas": "1.0.1",

--- a/upstream-configuration/composer.json
+++ b/upstream-configuration/composer.json
@@ -20,7 +20,7 @@
         "asuwebplatforms/webspark-theme-renovation": "1.0.37",
         "drupal/seckit": "2.0.0",
         "asuwebplatforms/webspark-module-asu_brand": "1.2.12",
-        "drupal/radix": "4.10.0",
+        "drupal/radix": "4.11.0",
         "asuwebplatforms/webspark-profile-webspark": "1.1.12",
         "drupal/components" : "2.4.0",
         "npm-asset/select2": "4.1.0-RC.0",

--- a/upstream-configuration/composer.json
+++ b/upstream-configuration/composer.json
@@ -56,7 +56,7 @@
         "asuwebplatforms/webspark-module-asu_components_appearance": "1.0.1",
         "drupal/layout_section_classes": "1.2.0",
         "drupal/field_group": "3.4.0",
-        "drupal/metatag": "1.19.0",
+        "drupal/metatag": "1.22.0",
         "asuwebplatforms/webspark-module-webspark_ckeditor_plugins": "1.0.6",
         "drupal/layout_builder_component_attributes": "2.0.1",
         "asuwebplatforms/webspark-module-asu_user": "1.1.0",

--- a/upstream-configuration/composer.json
+++ b/upstream-configuration/composer.json
@@ -43,7 +43,7 @@
         "drupal/current_page_crumb": "1.3.0",
         "drupal/pathauto": "1.9.0",
         "asuwebplatforms/webspark-module-webspark_isearch": "1.0.2",
-        "drupal/media_library_form_element": "2.0.3",
+        "drupal/media_library_form_element": "2.0.4",
         "drupal/admin_toolbar": "3.2.1",
         "drupal/allowed_formats": "1.5",
         "drupal/field_menu": "2.0.1",

--- a/upstream-configuration/composer.json
+++ b/upstream-configuration/composer.json
@@ -68,7 +68,7 @@
         "ckeditor/fakeobjects": "4.16.0",
         "ckeditor/link": "4.16.1",
         "drupal/redirect": "1.8.0",
-        "drupal/simple_sitemap": "4.1.1",
+        "drupal/simple_sitemap": "4.1.3",
         "drupal/config_readonly": "1.0.0-beta4",
         "drupal/config_update": "1.7.0",
         "drupal/webform": "6.1.2",

--- a/upstream-configuration/composer.json
+++ b/upstream-configuration/composer.json
@@ -73,7 +73,7 @@
         "drupal/config_update": "1.7.0",
         "drupal/webform": "6.1.2",
         "drupal/robotstxt": "1.4",
-        "drupal/captcha": "1.2",
+        "drupal/captcha": "1.5",
         "drupal/schema_metatag": "2.3",
         "drupal/editoria11y": "1.0",
         "drupal/decorative_image_widget":"1.0.0-alpha4",

--- a/upstream-configuration/composer.json
+++ b/upstream-configuration/composer.json
@@ -45,7 +45,7 @@
         "asuwebplatforms/webspark-module-webspark_isearch": "1.0.2",
         "drupal/media_library_form_element": "2.0.3",
         "drupal/admin_toolbar": "3.2.1",
-        "drupal/allowed_formats": "1.4.0",
+        "drupal/allowed_formats": "1.5",
         "drupal/field_menu": "2.0.1",
         "asuwebplatforms/webspark-module-asu_news": "1.2.4",
         "asuwebplatforms/webspark-module-asu_events": "1.3.0",

--- a/upstream-configuration/composer.json
+++ b/upstream-configuration/composer.json
@@ -71,7 +71,7 @@
         "drupal/simple_sitemap": "4.1.3",
         "drupal/config_readonly": "1.0.0-beta4",
         "drupal/config_update": "1.7.0",
-        "drupal/webform": "6.1.2",
+        "drupal/webform": "6.2.0-beta3",
         "drupal/robotstxt": "1.4",
         "drupal/captcha": "1.5",
         "drupal/schema_metatag": "2.3",

--- a/upstream-configuration/composer.json
+++ b/upstream-configuration/composer.json
@@ -44,7 +44,7 @@
         "drupal/pathauto": "1.9.0",
         "asuwebplatforms/webspark-module-webspark_isearch": "1.0.2",
         "drupal/media_library_form_element": "2.0.3",
-        "drupal/admin_toolbar": "3.1.0",
+        "drupal/admin_toolbar": "3.2.1",
         "drupal/allowed_formats": "1.4.0",
         "drupal/field_menu": "2.0.1",
         "asuwebplatforms/webspark-module-asu_news": "1.2.4",

--- a/upstream-configuration/composer.json
+++ b/upstream-configuration/composer.json
@@ -41,7 +41,7 @@
         "drupal/linkit": "6.0.0-beta3",
         "bower-asset/fontawesome": "^5.15",
         "drupal/current_page_crumb": "1.3.0",
-        "drupal/pathauto": "1.9.0",
+        "drupal/pathauto": "1.11.0",
         "asuwebplatforms/webspark-module-webspark_isearch": "1.0.2",
         "drupal/media_library_form_element": "2.0.4",
         "drupal/admin_toolbar": "3.2.1",

--- a/upstream-configuration/composer.json
+++ b/upstream-configuration/composer.json
@@ -29,7 +29,7 @@
         "asuwebplatforms/webspark-module-webspark_utility": "1.1.6",
         "asuwebplatforms/webspark_module_renovation_layouts": "1.0.5",
         "drupal/select2" : "1.13.0",
-        "drupal/paragraphs" : "1.13.0",
+        "drupal/paragraphs" : "1.15.0",
         "drupal/fontawesome" : "2.24.0",
         "drupal/devel": "^4.1",
         "drupal/devel_kint_extras": "^1.0",

--- a/upstream-configuration/composer.json
+++ b/upstream-configuration/composer.json
@@ -67,7 +67,7 @@
         "drupal/anchor_link": "2.5.0",
         "ckeditor/fakeobjects": "4.16.0",
         "ckeditor/link": "4.16.1",
-        "drupal/redirect": "1.7.0",
+        "drupal/redirect": "1.8.0",
         "drupal/simple_sitemap": "4.1.1",
         "drupal/config_readonly": "1.0.0-beta4",
         "drupal/config_update": "1.7.0",

--- a/upstream-configuration/composer.json
+++ b/upstream-configuration/composer.json
@@ -55,7 +55,7 @@
         "asuwebplatforms/webspark-module-asu_react_core": "1.4.0",
         "asuwebplatforms/webspark-module-asu_components_appearance": "1.0.1",
         "drupal/layout_section_classes": "1.1.0",
-        "drupal/field_group": "3.2.0",
+        "drupal/field_group": "3.4.0",
         "drupal/metatag": "1.19.0",
         "asuwebplatforms/webspark-module-webspark_ckeditor_plugins": "1.0.6",
         "drupal/layout_builder_component_attributes": "2.0.1",

--- a/upstream-configuration/composer.json
+++ b/upstream-configuration/composer.json
@@ -35,7 +35,7 @@
         "drupal/devel_kint_extras": "^1.0",
         "drupal/crop": "2.3.0",
         "drupal/image_widget_crop": "2.3.0",
-        "drupal/layout_builder_restrictions" : "2.12.0",
+        "drupal/layout_builder_restrictions" : "2.16.0",
         "asuwebplatforms/webspark_module_views_pager": "1.0.3",
         "asuwebplatforms/webspark-module-webspark_blocks": "1.1.16",
         "drupal/linkit": "6.0.0-beta3",

--- a/upstream-configuration/composer.json
+++ b/upstream-configuration/composer.json
@@ -30,7 +30,7 @@
         "asuwebplatforms/webspark_module_renovation_layouts": "1.0.5",
         "drupal/select2" : "1.13.0",
         "drupal/paragraphs" : "1.13.0",
-        "drupal/fontawesome" : "2.21.0",
+        "drupal/fontawesome" : "2.24.0",
         "drupal/devel": "^4.1",
         "drupal/devel_kint_extras": "^1.0",
         "drupal/crop": "2.3.0",

--- a/upstream-configuration/composer.json
+++ b/upstream-configuration/composer.json
@@ -34,7 +34,7 @@
         "drupal/devel": "^4.1",
         "drupal/devel_kint_extras": "^1.0",
         "drupal/crop": "2.3.0",
-        "drupal/image_widget_crop": "2.3.0",
+        "drupal/image_widget_crop": "2.4.0",
         "drupal/layout_builder_restrictions" : "2.16.0",
         "asuwebplatforms/webspark_module_views_pager": "1.0.3",
         "asuwebplatforms/webspark-module-webspark_blocks": "1.1.16",

--- a/upstream-configuration/composer.json
+++ b/upstream-configuration/composer.json
@@ -33,7 +33,7 @@
         "drupal/fontawesome" : "2.21.0",
         "drupal/devel": "^4.1",
         "drupal/devel_kint_extras": "^1.0",
-        "drupal/crop": "2.1.0",
+        "drupal/crop": "2.3.0",
         "drupal/image_widget_crop": "2.3.0",
         "drupal/layout_builder_restrictions" : "2.12.0",
         "asuwebplatforms/webspark_module_views_pager": "1.0.3",


### PR DESCRIPTION
https://asudev.jira.com/browse/WS2-1464
This will bring all the contributed modules up to their latest recommended versions. It also updates Drush from version 10 to 11. I did each one as a separate commit in order to make it easier to test and/or roll-back. We can squash the commits if we want later...