### PR TITLE
update webdir module release

### DIFF
--- a/upstream-configuration/composer.json
+++ b/upstream-configuration/composer.json
@@ -79,7 +79,7 @@
         "drupal/decorative_image_widget":"1.0.0-alpha4",
         "drupal/block_field": "1.0.0-rc4",
         "asuwebplatforms/webspark-module-webspark_cas": "1.0.4",
-        "asuwebplatforms/webspark-module-webspark_webdir": "1.2.1",
+        "asuwebplatforms/webspark-module-webspark_webdir": "1.2.2",
         "drupal/field_states_ui": "2.0",
         "drupal/ctools": "^3.11.0"
     },

--- a/upstream-configuration/composer.json
+++ b/upstream-configuration/composer.json
@@ -83,5 +83,5 @@
         "drupal/field_states_ui": "2.0",
         "drupal/ctools": "^3.11.0"
     },
-    "version": "0.2.26"
+    "version": "0.2.27"
 }


### PR DESCRIPTION
When updating ASUIS to the latest webspark-release-testing version, I noticed that the webspark_webdir module didn't have a release for the latest work, and it was causing update.php to barf. So, this is to fix that.