### PR TITLE
WS2 release - remove unmet and unneeded dependency

### DIFF
--- a/web/modules/webspark/webspark_utility/config/install/field.storage.block_content.field_heading.yml
+++ b/web/modules/webspark/webspark_utility/config/install/field.storage.block_content.field_heading.yml
@@ -3,9 +3,6 @@ status: true
 dependencies:
   module:
     - block_content
-  enforced:
-    module:
-      - webspark_blocks
 id: block_content.field_heading
 field_name: field_heading
 entity_type: block_content


### PR DESCRIPTION
Dependency that's unneeded crept back into yaml and caused error in the install:
```
Drupal\Core\Config\UnmetDependenciesException::create('webspark_utility', Array) (Line: 527)
Drupal\Core\Config\ConfigInstaller->checkConfigurationToInstall('module', 'webspark_utility') (Line: 132)
Drupal\Core\ProxyClass\Config\ConfigInstaller->checkConfigurationToInstall('module', 'webspark_utility') (Line: 206)
Drupal\Core\Extension\ModuleInstaller->install(Array, ) (Line: 83)
Drupal\Core\ProxyClass\Extension\ModuleInstaller->install(Array, ) (Line: 1909)
_install_module_batch('webspark_utility', 'WebsSpark Utility', Array) (Line: 296)
_batch_process() (Line: 187)
_batch_progress_page() (Line: 87)
_batch_page(Object) (Line: 673)
install_run_task(Array, Array) (Line: 578)
install_run_tasks(Array, NULL) (Line: 121)
install_drupal(Object) (Line: 48)
```
PR removes it.

Replicates https://github.com/ASUWebPlatforms/webspark-ci/pull/603 from `webspark-ci` repo.