### PR TITLE
WS2-2223 / 2575 - undo update hook

### DIFF
--- a/upstream-configuration/composer.json
+++ b/upstream-configuration/composer.json
@@ -68,5 +68,5 @@
     "config": {
         "sort-packages": true
     },
-    "version": "2.15.2"
+    "version": "2.15.3"
 }

--- a/web/profiles/webspark/webspark/webspark.info.yml
+++ b/web/profiles/webspark/webspark/webspark.info.yml
@@ -2,7 +2,7 @@ name: Webspark
 type: profile
 core_version_requirement: ^9.0 || ^10
 description: 'ASU custom profile.'
-version: 2.15.2
+version: 2.15.3
 distribution:
   name: 'Webspark'
 install:

--- a/web/profiles/webspark/webspark/webspark.install
+++ b/web/profiles/webspark/webspark/webspark.install
@@ -746,16 +746,20 @@ function webspark_update_10013(&$sandbox): void {
 /**
  * WS2-2223 - Changed comments permissions and register: admin_only
  */
+// We cannot read in WHOLE role permissions after a site has been launched.
+// This overwrites user permissions that have been customized after the fact.
+// Commenting it out. New sites will get the new permissions. Existing sites can
+// apply manually.
 function webspark_update_10014(&$sandbox): void{
-  \Drupal::state()->set('configuration_locked', FALSE);
-
-  //Changed comments permissions
-  \Drupal::service('asu_config.config_manager')->updateConfigFile('user.role.authenticated');
-  \Drupal::service('asu_config.config_manager')->updateConfigFile('user.role.anonymous');
-  //Changed register: admin_only
-  \Drupal::service('asu_config.config_manager')->updateConfigFile('user.settings');
-
-  \Drupal::state()->set('configuration_locked', TRUE);
+//  \Drupal::state()->set('configuration_locked', FALSE);
+//
+//  //Changed comments permissions
+//  \Drupal::service('asu_config.config_manager')->updateConfigFile('user.role.authenticated');
+//  \Drupal::service('asu_config.config_manager')->updateConfigFile('user.role.anonymous');
+//  //Changed register: admin_only
+//  \Drupal::service('asu_config.config_manager')->updateConfigFile('user.settings');
+//
+//  \Drupal::state()->set('configuration_locked', TRUE);
 }
 
 /**


### PR DESCRIPTION
### Description

We cannot read in WHOLE role permissions after a site has been launched. This overwrites user permissions that have been customized after the fact. Commenting it out. New sites will get the new permissions. Existing sites can apply manually.
### Links

- [JIRA ticket](https://asudev.jira.com/browse/WS2-2575)

